### PR TITLE
(not for merging) Require fsevents 1.2.9 or higher so this works on Node v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "xmlbuilder": "^8.2.2"
   },
   "optionalDependencies": {
-    "fsevents": "1.2.4"
+    "fsevents": "^1.2.9"
   },
   "devDependencies": {
     "byline": "^5.0.0",


### PR DESCRIPTION
*Note* This fork and this PR only exist so that we can have a branch with one change, see below for details. We don't intend to merge this PR, or maintain this branch, in the long term. It's a tactical fix to help a legacy project upgrade to Node 12.

If you would like to keep using Elm 0.19.0, but want to use Node 12,
then you run into an issue where fsevents 1.2.4 won't install.

Basically:

- You pin elm-test to 0.19.0-rev6
- elm-test has pinned fsevents to exactly 1.2.4
  (maybe an oversight? It's not a requirement in newer versions of elm-test)
- fsevents versions 1.2.9 is the first version to work with Node 12
- You cannot use yarn "resolutions" to solve this issue as that effectively
  makes fsevents a required dependency, rather than an optional dependency,
  and fsevents cannot be installed on Linux, so breaks CI builds.
